### PR TITLE
This fixes a really nasty bug in the renameSampleFile step. It put too c...

### DIFF
--- a/src/main/java/io/seqware/pancancer/CgpCnIndelSnvStrWorkflow.java
+++ b/src/main/java/io/seqware/pancancer/CgpCnIndelSnvStrWorkflow.java
@@ -783,6 +783,7 @@ public class CgpCnIndelSnvStrWorkflow extends AbstractWorkflowDataModel {
       .addArgument(getWorkflowBaseDir()+ "/bin/execute_with_sample.pl " + bam)
       .addArgument("cp " + dir + "/" + "%SM%." + extension)
       .addArgument(OUTDIR + "/" + "%SM%." + workflowName + "." + dateString + ".somatic." + extension)
+      .addArgument(";");
       ;
     }
     return thisJob;


### PR DESCRIPTION
...ommands on the same line without a ';' when you have multiple tumors (I'm guessing). So most donors worked fine except for mulit-tumor donors. Yikes!